### PR TITLE
Add bulb/light + group control (brightness, color, temp, groups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ typings/
 example/scratch
 # macOS
 .DS_Store
+
+# token cache (contains access/refresh tokens)
+/scratch/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,23 @@ Use this helper methods to interact with wyze-node.
 - wyze.getDeviceStatus(device)
 - wyze.getDeviceState(device)
 
+## Bulb / light helpers
 
+These take a `device` object (from `getDeviceByName` / `getDeviceByMac`) and
+automatically pick the right transport: mesh bulbs and light strips apply
+properties via `set_mesh_property`; regular bulbs use `set_property`.
+
+- wyze.setBrightness(device, brightness)  // 0-100
+- wyze.setColorTemp(device, kelvin)       // ~1800-6500 K
+- wyze.setColor(device, 'RRGGBB')         // color/mesh bulbs only, e.g. 'FF0000'
+- wyze.setSunMatch(device, on)            // mimic natural sunlight
+
+```
+const bulb = await wyze.getDeviceByName('Noel’s Lamp')
+await wyze.setBrightness(bulb, 40)
+await wyze.setColor(bulb, 'FF8800')   // warm orange
+await wyze.setColorTemp(bulb, 2700)   // or back to warm white
+```
 
 ## Internal methods
 
@@ -91,6 +107,7 @@ Use this helper methods to interact with wyze-node.
 - wyze.getRefreshToken()
 - wyze.getObjectList()
 - wyze.runAction(instanceId, providerKey, actionKey)
+- wyze.runActionList(instanceId, providerKey, actionKey, plist)
 - wyze.getDeviceInfo(deviceMac, deviceModel)
 - wyze.getPropertyList(deviceMac, deviceModel)
 - wyze.setProperty(deviceMac, deviceModel, propertyId, propertyValue)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ await wyze.setColor(bulb, 'FF8800')   // warm orange
 await wyze.setColorTemp(bulb, 2700)   // or back to warm white
 ```
 
+## Group helpers
+
+Wyze has no native group-action API, so these fan out to a group's members.
+Mesh bulbs are applied in a single batched `run_action_list` call; any non-mesh
+members fall back to per-device `set_property`.
+
+- wyze.getDeviceGroupByName(name)
+- wyze.turnOnGroup(group)
+- wyze.turnOffGroup(group)
+- wyze.setGroupBrightness(group, brightness)   // 0-100
+- wyze.setGroupColorTemp(group, kelvin)        // ~1800-6500 K
+- wyze.setGroupColor(group, 'RRGGBB')          // color/mesh bulbs
+
+```
+const office = await wyze.getDeviceGroupByName('Office Lights')
+await wyze.setGroupColorTemp(office, 3000)   // all 7 bulbs, one request
+await wyze.turnOffGroup(office)
+```
+
 ## Internal methods
 
 - wyze.login()
@@ -108,6 +127,7 @@ await wyze.setColorTemp(bulb, 2700)   // or back to warm white
 - wyze.getObjectList()
 - wyze.runAction(instanceId, providerKey, actionKey)
 - wyze.runActionList(instanceId, providerKey, actionKey, plist)
+- wyze.runActionListBatch(actions)  // apply across multiple devices in one call
 - wyze.getDeviceInfo(deviceMac, deviceModel)
 - wyze.getPropertyList(deviceMac, deviceModel)
 - wyze.setProperty(deviceMac, deviceModel, propertyId, propertyValue)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ const BULB_PROPERTY_IDS = {
   sunMatch: 'P1528',     // 0/1 — mimic natural sunlight
 }
 
+// Model codes that drive transport selection. Mesh bulbs and light strips apply
+// properties via set_mesh_property (run_action_list); plain white bulbs don't.
+// Model is used (not product_type) because group members only expose the model.
+const BULB_MODELS = {
+  lightStrip: ['HL_LSL', 'HL_LSLP'],
+  mesh: ['WLPA19C', 'HL_LSL', 'HL_LSLP'],
+}
+
 class Wyze {
   /**
    * @param {object} options
@@ -354,6 +362,18 @@ class Wyze {
   * @returns {data}
   */
   async runActionList(instanceId, providerKey, actionKey, plist = []) {
+    return await this.runActionListBatch([
+      { mac: instanceId, model: providerKey, actionKey, plist },
+    ])
+  }
+
+  /**
+  * run an action list across one or more devices in a single request. This is
+  * how the app applies a property to a whole group of mesh bulbs at once.
+  * @param {Array<{mac:string,model:string,actionKey:string,plist:Array<{pid:string,pvalue:(string|number)}>}>} actions
+  * @returns {data}
+  */
+  async runActionListBatch(actions = []) {
     let result
     try {
       await this.getTokens();
@@ -361,26 +381,24 @@ class Wyze {
         await this.login()
       }
       const data = {
-        action_list: [
-          {
-            action_key: actionKey,
-            action_params: {
-              list: [
-                {
-                  mac: instanceId,
-                  plist: plist.map(p => ({ pid: p.pid, pvalue: String(p.pvalue) })),
-                },
-              ],
-            },
-            instance_id: instanceId,
-            provider_key: providerKey,
+        action_list: actions.map(a => ({
+          action_key: a.actionKey,
+          action_params: {
+            list: [
+              {
+                mac: a.mac,
+                plist: (a.plist || []).map(p => ({ pid: p.pid, pvalue: String(p.pvalue) })),
+              },
+            ],
           },
-        ],
+          instance_id: a.mac,
+          provider_key: a.model,
+        })),
       }
       result = await axios.post(`${this.baseUrl}/app/v2/auto/run_action_list`, await this.getRequestBodyData(data))
       if (result.data.msg === 'AccessTokenError') {
         await this.getRefreshToken()
-        return this.runActionList(instanceId, providerKey, actionKey, plist)
+        return this.runActionListBatch(actions)
       }
     }
     catch (e) {
@@ -495,22 +513,32 @@ class Wyze {
   * set_property.
   */
 
+  // device objects use `mac`; group members use `device_mac`.
+  deviceMac(device) {
+    return device.mac || device.device_mac
+  }
+
   isMeshBulb(device) {
+    const model = (device.product_model || '').toUpperCase()
+    if (BULB_MODELS.mesh.includes(model)) return true
     const type = (device.product_type || '').toLowerCase()
     return type === 'meshlight' || type === 'lightstrip'
   }
 
   isLightStrip(device) {
+    const model = (device.product_model || '').toUpperCase()
+    if (BULB_MODELS.lightStrip.includes(model)) return true
     return (device.product_type || '').toLowerCase() === 'lightstrip'
   }
 
   async setBulbProperties(device, plist) {
+    const mac = this.deviceMac(device)
     if (this.isMeshBulb(device)) {
-      return await this.runActionList(device.mac, device.product_model, 'set_mesh_property', plist)
+      return await this.runActionList(mac, device.product_model, 'set_mesh_property', plist)
     }
     let result
     for (const p of plist) {
-      result = await this.setProperty(device.mac, device.product_model, p.pid, String(p.pvalue))
+      result = await this.setProperty(mac, device.product_model, p.pid, String(p.pvalue))
     }
     return result
   }
@@ -558,6 +586,90 @@ class Wyze {
   */
   async setSunMatch(device, on = true) {
     return await this.setBulbProperties(device, [{ pid: BULB_PROPERTY_IDS.sunMatch, pvalue: on ? 1 : 0 }])
+  }
+
+  /**
+  * Group helpers
+  *
+  * Wyze has no native group-action endpoint, so these fan out to the group's
+  * member devices. Mesh bulbs are applied in a single batched run_action_list
+  * call; any non-mesh members fall back to per-device set_property.
+  */
+
+  /**
+  * getDeviceGroupByName
+  */
+  async getDeviceGroupByName(name) {
+    const groups = await this.getDeviceGroupsList()
+    return (groups || []).find(g => (g.group_name || '').toLowerCase() === String(name).toLowerCase())
+  }
+
+  async setGroupProperties(group, plist) {
+    const members = (group && group.device_list) || []
+    const results = []
+    const mesh = members.filter(m => this.isMeshBulb(m))
+    const regular = members.filter(m => !this.isMeshBulb(m))
+    if (mesh.length) {
+      results.push(await this.runActionListBatch(mesh.map(m => ({
+        mac: this.deviceMac(m),
+        model: m.product_model,
+        actionKey: 'set_mesh_property',
+        plist,
+      }))))
+    }
+    for (const m of regular) {
+      for (const p of plist) {
+        results.push(await this.setProperty(this.deviceMac(m), m.product_model, p.pid, String(p.pvalue)))
+      }
+    }
+    return results
+  }
+
+  async _groupRunAction(group, actionKey) {
+    const members = (group && group.device_list) || []
+    const results = []
+    for (const m of members) {
+      results.push(await this.runAction(this.deviceMac(m), m.product_model, actionKey))
+    }
+    return results
+  }
+
+  /**
+  * turnOnGroup / turnOffGroup
+  */
+  async turnOnGroup(group) {
+    return await this._groupRunAction(group, 'power_on')
+  }
+
+  async turnOffGroup(group) {
+    return await this._groupRunAction(group, 'power_off')
+  }
+
+  /**
+  * setGroupBrightness — brightness 0..100 for every bulb in the group
+  */
+  async setGroupBrightness(group, brightness) {
+    const value = Math.max(0, Math.min(100, Math.round(Number(brightness))))
+    return await this.setGroupProperties(group, [{ pid: BULB_PROPERTY_IDS.brightness, pvalue: value }])
+  }
+
+  /**
+  * setGroupColorTemp — color temperature in Kelvin for every bulb in the group
+  */
+  async setGroupColorTemp(group, kelvin) {
+    const value = Math.max(1800, Math.min(6500, Math.round(Number(kelvin))))
+    return await this.setGroupProperties(group, [{ pid: BULB_PROPERTY_IDS.colorTemp, pvalue: value }])
+  }
+
+  /**
+  * setGroupColor — hex 'RRGGBB' for every (color/mesh) bulb in the group
+  */
+  async setGroupColor(group, hex) {
+    const value = String(hex).replace(/^#/, '').toUpperCase()
+    if (!/^[0-9A-F]{6}$/.test(value)) {
+      throw new Error(`Invalid color '${hex}': expected 6-digit hex like 'FF0000'`)
+    }
+    return await this.setGroupProperties(group, [{ pid: BULB_PROPERTY_IDS.color, pvalue: value }])
   }
 
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,15 @@ const moment = require('moment')
 const LocalStorage = require('node-localstorage').LocalStorage
 const localStorage = new LocalStorage('./scratch')
 
+// Property IDs used by the bulb/light convenience helpers.
+const BULB_PROPERTY_IDS = {
+  brightness: 'P1501',   // 0-100
+  colorTemp: 'P1502',    // color temperature in Kelvin (~1800-6500)
+  color: 'P1507',        // 'RRGGBB' hex (mesh / color bulbs only)
+  controlLight: 'P1508', // light strips: 1 = color, 2 = temperature
+  sunMatch: 'P1528',     // 0/1 — mimic natural sunlight
+}
+
 class Wyze {
   /**
    * @param {object} options
@@ -335,6 +344,52 @@ class Wyze {
   }
 
   /**
+  * run an action list against a single device. Used by mesh bulbs / light
+  * strips, which apply properties via `set_mesh_property` instead of the plain
+  * set_property endpoint.
+  * @param {string} instanceId device mac
+  * @param {string} providerKey device model
+  * @param {string} actionKey e.g. 'set_mesh_property'
+  * @param {Array<{pid:string,pvalue:(string|number)}>} plist properties to set
+  * @returns {data}
+  */
+  async runActionList(instanceId, providerKey, actionKey, plist = []) {
+    let result
+    try {
+      await this.getTokens();
+      if (!this.accessToken) {
+        await this.login()
+      }
+      const data = {
+        action_list: [
+          {
+            action_key: actionKey,
+            action_params: {
+              list: [
+                {
+                  mac: instanceId,
+                  plist: plist.map(p => ({ pid: p.pid, pvalue: String(p.pvalue) })),
+                },
+              ],
+            },
+            instance_id: instanceId,
+            provider_key: providerKey,
+          },
+        ],
+      }
+      result = await axios.post(`${this.baseUrl}/app/v2/auto/run_action_list`, await this.getRequestBodyData(data))
+      if (result.data.msg === 'AccessTokenError') {
+        await this.getRefreshToken()
+        return this.runActionList(instanceId, providerKey, actionKey, plist)
+      }
+    }
+    catch (e) {
+      throw e
+    }
+    return result.data
+  }
+
+  /**
   * Helper functions
   */
 
@@ -429,6 +484,80 @@ class Wyze {
       state = device.device_params.open_close_state !== undefined ? (device.device_params.open_close_state === 1 ? 'open' : 'closed') : ''
     }
     return state
+  }
+
+  /**
+  * Bulb / light helpers
+  *
+  * Each accepts a device object (from getDeviceByName / getDeviceByMac) and
+  * picks the right transport automatically: mesh bulbs and light strips apply
+  * properties via run_action_list (set_mesh_property); regular bulbs use
+  * set_property.
+  */
+
+  isMeshBulb(device) {
+    const type = (device.product_type || '').toLowerCase()
+    return type === 'meshlight' || type === 'lightstrip'
+  }
+
+  isLightStrip(device) {
+    return (device.product_type || '').toLowerCase() === 'lightstrip'
+  }
+
+  async setBulbProperties(device, plist) {
+    if (this.isMeshBulb(device)) {
+      return await this.runActionList(device.mac, device.product_model, 'set_mesh_property', plist)
+    }
+    let result
+    for (const p of plist) {
+      result = await this.setProperty(device.mac, device.product_model, p.pid, String(p.pvalue))
+    }
+    return result
+  }
+
+  /**
+  * setBrightness — brightness 0..100
+  */
+  async setBrightness(device, brightness) {
+    const value = Math.max(0, Math.min(100, Math.round(Number(brightness))))
+    return await this.setBulbProperties(device, [{ pid: BULB_PROPERTY_IDS.brightness, pvalue: value }])
+  }
+
+  /**
+  * setColorTemp — color temperature in Kelvin (~1800..6500)
+  */
+  async setColorTemp(device, kelvin) {
+    const value = Math.max(1800, Math.min(6500, Math.round(Number(kelvin))))
+    const plist = [{ pid: BULB_PROPERTY_IDS.colorTemp, pvalue: value }]
+    if (this.isLightStrip(device)) {
+      plist.push({ pid: BULB_PROPERTY_IDS.controlLight, pvalue: 2 }) // temperature mode
+    }
+    return await this.setBulbProperties(device, plist)
+  }
+
+  /**
+  * setColor — hex 'RRGGBB' (mesh / color bulbs and light strips only)
+  */
+  async setColor(device, hex) {
+    if (!this.isMeshBulb(device)) {
+      throw new Error('setColor is only supported on color/mesh bulbs and light strips')
+    }
+    const value = String(hex).replace(/^#/, '').toUpperCase()
+    if (!/^[0-9A-F]{6}$/.test(value)) {
+      throw new Error(`Invalid color '${hex}': expected 6-digit hex like 'FF0000'`)
+    }
+    const plist = [{ pid: BULB_PROPERTY_IDS.color, pvalue: value }]
+    if (this.isLightStrip(device)) {
+      plist.push({ pid: BULB_PROPERTY_IDS.controlLight, pvalue: 1 }) // color mode
+    }
+    return await this.setBulbProperties(device, plist)
+  }
+
+  /**
+  * setSunMatch — mimic natural sunlight (on/off)
+  */
+  async setSunMatch(device, on = true) {
+    return await this.setBulbProperties(device, [{ pid: BULB_PROPERTY_IDS.sunMatch, pvalue: on ? 1 : 0 }])
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "index.js",


### PR DESCRIPTION
## What
Typed helpers so callers don't need raw Wyze property IDs:

- `setBrightness(device, 0-100)`
- `setColorTemp(device, kelvin)` — ~1800–6500 K
- `setColor(device, 'RRGGBB')` — color/mesh bulbs (validates hex)
- `setSunMatch(device, on)`

Each takes a `device` object (from `getDeviceByName`/`getDeviceByMac`) and **routes by device type automatically**:
- **Mesh bulbs / light strips** → new `runActionList()` (`/app/v2/auto/run_action_list` with `set_mesh_property`)
- **Regular bulbs** → existing `setProperty()`
- Light strips also get their control-light mode set (color vs temperature)

## Why
The library could already flip bulbs on/off, but brightness/color/temperature required hand-crafted `setProperty` calls with magic PIDs — and mesh bulbs (the majority of Wyze's color bulbs) don't even work through `set_property`; they need `run_action_list`. This closes the biggest day-to-day gap vs the Python `wyze-sdk`.

Property IDs / ranges and the mesh-vs-regular split match the [`wyze-sdk`](https://github.com/shauntarves/wyze-sdk) reference (`P1501` brightness, `P1502` color temp, `P1507` color, `P1508` control mode, `P1528` sun match).

## Testing
- ✅ Syntax check; all helpers present
- ✅ Transport routing: `MeshLight`/`LightStrip` → `runActionList`, others → `setProperty`
- ✅ Validation: `setColor` rejects non-mesh bulbs and malformed hex before any network call
- ⏳ Live hardware test (changing a real bulb) — pending, to be run against an opted-in device

Also: gitignores the `/scratch` token cache. Bumps to 2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)