### PR TITLE
Add Wyze Robot Vacuum control (signed Ex-service requests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ await wyze.setGroupColorTemp(office, 3000)   // all 7 bulbs, one request
 await wyze.turnOffGroup(office)
 ```
 
+## Vacuum helpers (Wyze Robot Vacuum)
+
+The vacuum lives on a separate Wyze service that requires signed requests; the
+library handles the signing for you.
+
+- wyze.getVacuumStatus(device)
+- wyze.startVacuum(device)    // begin / resume a sweep
+- wyze.pauseVacuum(device)
+- wyze.dockVacuum(device)     // return to charging dock
+- wyze.controlVacuum(device, type, value, rooms)  // low-level
+
+```
+const vac = await wyze.getDeviceByName('Home Vacuum')
+await wyze.startVacuum(vac)
+// …later…
+await wyze.dockVacuum(vac)
+```
+
 ## Internal methods
 
 - wyze.login()
@@ -128,6 +146,7 @@ await wyze.turnOffGroup(office)
 - wyze.runAction(instanceId, providerKey, actionKey)
 - wyze.runActionList(instanceId, providerKey, actionKey, plist)
 - wyze.runActionListBatch(actions)  // apply across multiple devices in one call
+- wyze.exServiceCall(svc, path, opts)  // signed request to a Wyze "Ex" service
 - wyze.getDeviceInfo(deviceMac, deviceModel)
 - wyze.getPropertyList(deviceMac, deviceModel)
 - wyze.setProperty(deviceMac, deviceModel, propertyId, propertyValue)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,28 @@
 'use strict'
 const axios = require('axios')
+const crypto = require('crypto')
 const md5 = require('md5')
 const moment = require('moment')
 const LocalStorage = require('node-localstorage').LocalStorage
 const localStorage = new LocalStorage('./scratch')
+
+const _md5hex = (s) => crypto.createHash('md5').update(String(s)).digest('hex')
+const _hmacMd5 = (key, body) => crypto.createHmac('md5', key).update(body).digest('hex')
+
+// Newer Wyze "Ex" services (vacuum, lock, …) live on their own hosts and require
+// signed requests: an HMAC-MD5 `signature2` keyed on md5(access_token + salt).
+const EX_SERVICES = {
+  venus: { // robot vacuum
+    baseUrl: 'https://wyze-venus-service-vn.wyzecam.com',
+    appId: 'venp_4c30f812828de875',
+    salt: 'CVCSNoa0ALsNEpgKls6ybVTVOmGzFoiq',
+    appVersion: '2.19.14',
+  },
+}
+
+// Vacuum control command codes (see wyze-sdk VenusDeviceControlRequest).
+const VACUUM_CONTROL_TYPE = { SWEEPING: 0, RECHARGE: 3, AREA_CLEAN: 6, QUICK_MAPPING: 7 }
+const VACUUM_CONTROL_VALUE = { STOP: 0, START: 1, PAUSE: 2, FALSE_PAUSE: 3 }
 
 // Property IDs used by the bulb/light convenience helpers.
 const BULB_PROPERTY_IDS = {
@@ -670,6 +689,103 @@ class Wyze {
       throw new Error(`Invalid color '${hex}': expected 6-digit hex like 'FF0000'`)
     }
     return await this.setGroupProperties(group, [{ pid: BULB_PROPERTY_IDS.color, pvalue: value }])
+  }
+
+  /**
+  * Signed request to a newer Wyze "Ex" service (vacuum, lock, …). These hosts
+  * require an HMAC-MD5 `signature2` over the request body (POST) or sorted
+  * params (GET), keyed on md5(access_token + service salt).
+  * @param {object} svc one of EX_SERVICES (baseUrl, appId, salt, appVersion)
+  * @param {string} path e.g. '/plugin/venus/<did>/control'
+  * @param {object} opts { method='POST', params, json }
+  * @returns {data}
+  */
+  async exServiceCall(svc, path, { method = 'POST', params = null, json = null } = {}) {
+    await this.getTokens();
+    if (!this.accessToken) {
+      await this.login()
+    }
+
+    const send = async () => {
+      const nonce = moment().valueOf()
+      const secret = _md5hex(`${this.accessToken}${svc.salt}`)
+      const headers = {
+        'appid': svc.appId,
+        'appinfo': `wyze_android_${svc.appVersion}`,
+        'phoneid': this.phoneId,
+        'User-Agent': `wyze_android_${svc.appVersion}`,
+        'access_token': this.accessToken,
+        'requestid': _md5hex(_md5hex(String(nonce))),
+        'Accept-Encoding': 'gzip',
+      }
+      let data
+      let axiosParams
+      if (method === 'GET') {
+        const p = { ...(params || {}), nonce }
+        const signStr = Object.keys(p).sort().map(k => `${k}=${p[k]}`).join('&')
+        headers['signature2'] = _hmacMd5(secret, signStr)
+        axiosParams = p
+      } else {
+        // build the exact JSON we sign and send (compact, so they match)
+        data = JSON.stringify({ ...(json || {}), nonce: String(nonce) })
+        headers['signature2'] = _hmacMd5(secret, data)
+        headers['Content-Type'] = 'application/json;charset=utf-8'
+      }
+      return await axios({ method, url: `${svc.baseUrl}${path}`, headers, data, params: axiosParams })
+    }
+
+    let result = await send()
+    const tokenError = result.data && (result.data.msg === 'AccessTokenError' ||
+      String(result.data.code) === '2001')
+    if (tokenError) {
+      await this.getRefreshToken()
+      result = await send()
+    }
+    return result.data
+  }
+
+  /**
+  * Vacuum helpers (Wyze Robot Vacuum). `device` is the vacuum device object;
+  * its mac is used as the venus device id (did).
+  */
+
+  vacuumDid(device) {
+    return device.did || device.mac || device.device_mac
+  }
+
+  async getVacuumStatus(device) {
+    const did = this.vacuumDid(device)
+    return await this.exServiceCall(EX_SERVICES.venus, `/plugin/venus/${did}/status`, {
+      method: 'GET', params: { did },
+    })
+  }
+
+  async controlVacuum(device, type, value, rooms = null) {
+    const did = this.vacuumDid(device)
+    const json = { type, value, vacuumMopMode: 0 }
+    if (rooms != null) json.rooms_id = Array.isArray(rooms) ? rooms : [rooms]
+    return await this.exServiceCall(EX_SERVICES.venus, `/plugin/venus/${did}/control`, { json })
+  }
+
+  /**
+  * startVacuum — begin/resume a full sweep
+  */
+  async startVacuum(device) {
+    return await this.controlVacuum(device, VACUUM_CONTROL_TYPE.SWEEPING, VACUUM_CONTROL_VALUE.START)
+  }
+
+  /**
+  * pauseVacuum — pause the current sweep
+  */
+  async pauseVacuum(device) {
+    return await this.controlVacuum(device, VACUUM_CONTROL_TYPE.SWEEPING, VACUUM_CONTROL_VALUE.PAUSE)
+  }
+
+  /**
+  * dockVacuum — send the vacuum back to its charging dock
+  */
+  async dockVacuum(device) {
+    return await this.controlVacuum(device, VACUUM_CONTROL_TYPE.RECHARGE, VACUUM_CONTROL_VALUE.START)
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "index.js",


### PR DESCRIPTION
## What
First support for a Wyze device that lives on a separate **"Ex" service** host (`wyze-venus-service-vn.wyzecam.com`), which requires **signed requests**.

- **`exServiceCall(svc, path, opts)`** — reusable signed-request helper. Builds the HMAC-MD5 `signature2` (keyed on `md5(access_token + service salt)`) plus `appid`/`appinfo`/`requestid`/`access_token` headers, for both POST (signs the compact JSON body) and GET (signs sorted params). Auto-refreshes on token errors.
- **Vacuum helpers:**
  - `getVacuumStatus(device)`
  - `startVacuum(device)` / `pauseVacuum(device)` / `dockVacuum(device)`
  - `controlVacuum(device, type, value, rooms)` (low-level)

Host, salt, app id, endpoint paths, and command codes all match the [`wyze-sdk`](https://github.com/shauntarves/wyze-sdk) venus service.

## Why
The vacuum (and the lock) couldn't be controlled at all — they're not on `api.wyzecam.com` and they require request signing the library didn't do. This adds that machinery once, so **lock support can reuse the same `exServiceCall`** next.

## Testing
- ✅ Signing verified **live**: a signed `getVacuumStatus` GET against a real `JA_RO2` returns `code: 1` with status data — proving the `signature2`/headers are correct.
- ⏳ Destructive controls (`startVacuum`/`dockVacuum`) use the identical signed POST path; not fired in CI to avoid physically moving the device.

Bumps to 2.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)