### PR TITLE
Add getCameraThumbnail()

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ await wyze.setGroupColorTemp(office, 3000)   // all 7 bulbs, one request
 await wyze.turnOffGroup(office)
 ```
 
+## Camera helpers
+
+- wyze.getCameraThumbnail(device)  // latest thumbnail URL (supported models only; not real-time)
+
+```
+const cam = await wyze.getDeviceByName('Driveway')
+const url = await wyze.getCameraThumbnail(cam)
+```
+
 ## Vacuum helpers (Wyze Robot Vacuum)
 
 The vacuum lives on a separate Wyze service that requires signed requests; the

--- a/index.js
+++ b/index.js
@@ -692,6 +692,17 @@ class Wyze {
   }
 
   /**
+  * getCameraThumbnail — returns the latest thumbnail URL for a camera, or null.
+  * Note: Wyze only populates this for some models (e.g. V2) and it is not
+  * real-time — it can lag behind by minutes/hours.
+  */
+  async getCameraThumbnail(device) {
+    const fresh = await this.getDeviceByMac(this.deviceMac(device))
+    const thumbs = fresh && fresh.device_params && fresh.device_params.camera_thumbnails
+    return (thumbs && thumbs.thumbnails_url) || null
+  }
+
+  /**
   * Signed request to a newer Wyze "Ex" service (vacuum, lock, …). These hosts
   * require an HMAC-MD5 `signature2` over the request body (POST) or sorted
   * params (GET), keyed on md5(access_token + service salt).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "index.js",


### PR DESCRIPTION
## What
`getCameraThumbnail(device)` — returns a camera's latest thumbnail URL from `device_params.camera_thumbnails.thumbnails_url`.

## Why
Addresses #20. The 2021 answer was "V2 only," but it now works on newer models too.

## Testing
✅ Live: returns real URLs for `ME_WCO3` and `HL_CAM4`; `null` for unsupported older cams (`WYZEC1-JZ`). Not real-time (Wyze updates periodically) — documented as such.

Bumps to 2.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)