### PR TITLE
Add Wyze Lock control (ford service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ await wyze.startVacuum(vac)
 await wyze.dockVacuum(vac)
 ```
 
+## Lock helpers (Wyze Lock)
+
+The lock uses the separate "ford" service (its own signing scheme, handled for
+you). `getLockInfo` is read-only and returns lock state, battery, door state, etc.
+
+- wyze.getLockInfo(device)
+- wyze.lockDoor(device)
+- wyze.unlockDoor(device)
+- wyze.controlLock(device, action)  // low-level ('remoteLock' / 'remoteUnlock')
+
+```
+const lock = await wyze.getDeviceByName('Front Door Lock')
+const info = await wyze.getLockInfo(lock)   // info.device.locker_status, power, etc.
+await wyze.lockDoor(lock)
+```
+
 ## Internal methods
 
 - wyze.login()
@@ -156,6 +172,7 @@ await wyze.dockVacuum(vac)
 - wyze.runActionList(instanceId, providerKey, actionKey, plist)
 - wyze.runActionListBatch(actions)  // apply across multiple devices in one call
 - wyze.exServiceCall(svc, path, opts)  // signed request to a Wyze "Ex" service
+- wyze.fordServiceCall(path, opts)  // signed request to the Wyze "ford" (lock) service
 - wyze.getDeviceInfo(deviceMac, deviceModel)
 - wyze.getPropertyList(deviceMac, deviceModel)
 - wyze.setProperty(deviceMac, deviceModel, propertyId, propertyValue)

--- a/index.js
+++ b/index.js
@@ -24,6 +24,21 @@ const EX_SERVICES = {
 const VACUUM_CONTROL_TYPE = { SWEEPING: 0, RECHARGE: 3, AREA_CLEAN: 6, QUICK_MAPPING: 7 }
 const VACUUM_CONTROL_VALUE = { STOP: 0, START: 1, PAUSE: 2, FALSE_PAUSE: 3 }
 
+// The lock lives on the "ford" service, which uses a different signing scheme:
+// sign = md5(quote_plus(method + path + sortedParams + appSecret)).
+const FORD = {
+  baseUrl: 'https://yd-saas-toc.wyzecam.com',
+  appKey: '275965684684dbdaf29a0ed9',
+  appSecret: '4deekof1ba311c5c33a9cb8e12787e8c',
+  appVersion: '2.19.14',
+}
+
+// Python urllib quote_plus equivalent (used inside the ford signature).
+const _quotePlus = (s) => encodeURIComponent(s)
+  .replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase())
+  .replace(/%20/g, '+')
+const _sortedParams = (obj) => Object.keys(obj).sort().map(k => `${k}=${obj[k]}`).join('&')
+
 // Property IDs used by the bulb/light convenience helpers.
 const BULB_PROPERTY_IDS = {
   brightness: 'P1501',   // 0-100
@@ -797,6 +812,87 @@ class Wyze {
   */
   async dockVacuum(device) {
     return await this.controlVacuum(device, VACUUM_CONTROL_TYPE.RECHARGE, VACUUM_CONTROL_VALUE.START)
+  }
+
+  /**
+  * Signed request to the "ford" lock service. Signing differs from exServiceCall:
+  * sign = md5(quote_plus(method + path + sortedParams + appSecret)), and the
+  * access token / key / timestamp / sign travel in the params (GET) or body
+  * (POST), not headers.
+  * @param {string} path e.g. '/openapi/lock/v1/info'
+  * @param {object} opts { method='GET', params, json }
+  * @returns {data}
+  */
+  async fordServiceCall(path, { method = 'GET', params = null, json = null } = {}) {
+    await this.getTokens();
+    if (!this.accessToken) {
+      await this.login()
+    }
+
+    const send = async () => {
+      const nonce = moment().valueOf()
+      const headers = {
+        'appVer': `And-${FORD.appVersion}`,
+        'language': 'en_US',
+        'Keep-Alive': 'timeout=120',
+        'User-Agent': 'okhttp/4.7.2',
+        'Accept-Encoding': 'gzip',
+      }
+      if (method === 'GET') {
+        const p = { ...(params || {}), access_token: this.accessToken, key: FORD.appKey, timestamp: String(nonce) }
+        p.sign = _md5hex(_quotePlus(`get${path}${_sortedParams(p)}${FORD.appSecret}`))
+        return await axios({ method: 'GET', url: `${FORD.baseUrl}${path}`, headers, params: p })
+      }
+      // POST uses camelCase accessToken (per the ford API)
+      const body = { ...(json || {}), accessToken: this.accessToken, key: FORD.appKey, timestamp: String(nonce) }
+      body.sign = _md5hex(_quotePlus(`${method.toLowerCase()}${path}${_sortedParams(body)}${FORD.appSecret}`))
+      headers['Content-Type'] = 'application/json;charset=utf-8'
+      return await axios({ method, url: `${FORD.baseUrl}${path}`, headers, data: JSON.stringify(body) })
+    }
+
+    let result = await send()
+    const d = result.data || {}
+    if (d.msg === 'AccessTokenError' || String(d.code) === '2001' || String(d.ErrNo) === '2001') {
+      await this.getRefreshToken()
+      result = await send()
+    }
+    return result.data
+  }
+
+  /**
+  * Lock helpers (Wyze Lock). The lock is addressed by `uuid`, which is the
+  * device mac with its model prefix removed (e.g. 'YD_BT1.abc123' -> 'abc123').
+  */
+
+  lockUuid(device) {
+    const mac = this.deviceMac(device) || ''
+    return mac.includes('.') ? mac.slice(mac.indexOf('.') + 1) : mac
+  }
+
+  /**
+  * getLockInfo — lock state, battery, door state, etc. (read-only)
+  */
+  async getLockInfo(device) {
+    return await this.fordServiceCall('/openapi/lock/v1/info', {
+      method: 'GET', params: { uuid: this.lockUuid(device), with_keypad: 1 },
+    })
+  }
+
+  async controlLock(device, action) {
+    return await this.fordServiceCall('/openapi/lock/v1/control', {
+      method: 'POST', json: { uuid: this.lockUuid(device), action },
+    })
+  }
+
+  /**
+  * lockDoor / unlockDoor
+  */
+  async lockDoor(device) {
+    return await this.controlLock(device, 'remoteLock')
+  }
+
+  async unlockDoor(device) {
+    return await this.controlLock(device, 'remoteUnlock')
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "index.js",


### PR DESCRIPTION
## What
Lock support on Wyze's separate **"ford" service** (`yd-saas-toc.wyzecam.com`), which uses a *different* signing scheme than the vacuum's Ex-service: `sign = md5(quote_plus(method + path + sortedParams + appSecret))`, with the access token / key / timestamp / sign carried in the params (GET) or body (POST).

- **`fordServiceCall(path, opts)`** — the signed transport
- **`getLockInfo(device)`** — read-only: lock state, battery, door state
- **`lockDoor(device)` / `unlockDoor(device)` / `controlLock(device, action)`**
- **`lockUuid(device)`** — derives the ford `uuid` from the device mac (`YD_BT1.abc` → `abc`)

Endpoints, actions (`remoteLock`/`remoteUnlock`), and uuid derivation match the [`wyze-sdk`](https://github.com/shauntarves/wyze-sdk) ford service.

## Why
Closes the biggest remaining gap (#4) — the lock couldn't be controlled at all.

## Testing
- ✅ Signing verified **live, read-only**: `getLockInfo` against a real `YD_BT1` returns `ErrNo: 0` with lock status (locked, battery %). 
- ⏳ `lockDoor`/`unlockDoor` use the identical signed POST path; intentionally **not** fired in testing (it's a physical front-door lock).

Keypad access-code management (also mentioned in #4) is not included here — possible follow-up.

Bumps to 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)