### PR TITLE
Add Wyze Scale support (body-composition data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ const hmsId = await wyze.getHmsId()
 await wyze.setHmsState(hmsId, 'away')
 ```
 
+## Scale (Wyze Scale)
+
+Read body-composition data (weight, BMI, body fat %, water %, BMR, etc.).
+
+- wyze.getScaleLatestRecord(device[, { userId }])  // most recent measurement
+- wyze.getScaleRecords(device[, { userId, startTime, endTime }])  // history range
+- wyze.getScaleFamilyMembers(device)
+
+```
+const scale = await wyze.getDeviceByName('Wyze Scale')
+const { data } = await wyze.getScaleLatestRecord(scale)
+const r = Array.isArray(data) ? data[0] : data
+console.log(r.weight, r.bmi, r.body_fat)
+```
+
 ## Vacuum helpers (Wyze Robot Vacuum)
 
 The vacuum lives on a separate Wyze service that requires signed requests; the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "src/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,11 @@ const HMS = {
   apiUrl: 'https://hms.api.wyze.com',
 }
 
+// Wyze Scale — also signed with the olive scheme, on its own host.
+const SCALE = {
+  baseUrl: 'https://wyze-scale-service.wyzecam.com',
+}
+
 // "web" signing for the camera WebRTC stream-info endpoint.
 const WEB = {
   baseUrl: 'https://app.wyzecam.com',
@@ -87,6 +92,7 @@ module.exports = {
   WEB,
   CAMERA_PROPERTY_IDS,
   FORD,
+  SCALE,
   BULB_PROPERTY_IDS,
   BULB_MODELS,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const localStorage = new LocalStorage('./scratch')
 
 const {
   EX_SERVICES, VACUUM_CONTROL_TYPE, VACUUM_CONTROL_VALUE, SIRIUS, DEFAULT_IOT_KEYS,
-  HMS, WEB, CAMERA_PROPERTY_IDS, FORD, BULB_PROPERTY_IDS, BULB_MODELS,
+  HMS, WEB, CAMERA_PROPERTY_IDS, FORD, SCALE, BULB_PROPERTY_IDS, BULB_MODELS,
 } = require('./constants')
 const { md5hex: _md5hex, hmacMd5: _hmacMd5, quotePlus: _quotePlus, sortedParams: _sortedParams } = require('./crypto')
 
@@ -1014,6 +1014,54 @@ class Wyze {
       return await this.monitoringProfileActive(hmsId, 1, 0)
     }
     throw new Error(`Unknown HMS mode '${mode}' (use 'home', 'away', or 'off')`)
+  }
+
+  /**
+  * Generic olive-signed GET to an arbitrary Wyze service host (used by the
+  * scale). Signs sorted params with the olive scheme and refreshes on token error.
+  */
+  async _oliveGet(baseUrl, path, params = {}) {
+    await this.getTokens();
+    if (!this.accessToken) {
+      await this.login()
+    }
+    const send = async () => {
+      const p = { ...params, nonce: String(moment().valueOf()) }
+      const body = Object.keys(p).sort().map(k => `${k}=${p[k]}`).join('&')
+      const headers = this._siriusHeaders(this._oliveSignature(body), false)
+      return await axios.get(`${baseUrl}${path}`, { headers, params: p })
+    }
+    let result = await send()
+    if (result.data && (result.data.msg === 'AccessTokenError' || String(result.data.code) === '2001')) {
+      await this.getRefreshToken()
+      result = await send()
+    }
+    return result.data
+  }
+
+  /**
+  * Scale helpers (Wyze Scale). `device` is the scale device object; its mac is
+  * the scale device id. Records include weight + body composition (BMI, body
+  * fat %, water %, BMR, etc.).
+  */
+  async getScaleLatestRecord(device, { userId } = {}) {
+    const params = { did: this.deviceMac(device) }
+    if (userId) params.family_member_id = userId
+    return await this._oliveGet(SCALE.baseUrl, '/plugin/scale/get_latest_record', params)
+  }
+
+  async getScaleRecords(device, { userId, startTime = 0, endTime = Date.now() } = {}) {
+    const params = {
+      did: this.deviceMac(device),
+      start_time: String(Math.floor(startTime / 1000)),
+      end_time: String(Math.floor(endTime / 1000)),
+    }
+    if (userId) params.family_member_id = userId
+    return await this._oliveGet(SCALE.baseUrl, '/plugin/scale/get_record_range', params)
+  }
+
+  async getScaleFamilyMembers(device) {
+    return await this._oliveGet(SCALE.baseUrl, '/plugin/scale/get_family_member', { did: this.deviceMac(device) })
   }
 
   /**

--- a/tests/api-surface.test.js
+++ b/tests/api-surface.test.js
@@ -32,6 +32,8 @@ const EXPECTED_METHODS = [
   'garageDoor', 'plugTurnOn', 'plugTurnOff',
   // hms
   'getPlanBindingListByUser', 'getHmsId', 'getHmsState', 'setHmsState',
+  // scale
+  'getScaleLatestRecord', 'getScaleRecords', 'getScaleFamilyMembers',
   // cameras
   'getCameras', 'getCameraByName', 'getOnlineCameras', 'getOfflineCameras',
   'getCameraThumbnail', 'cameraTurnOn', 'cameraTurnOff', 'cameraMotionOn', 'cameraMotionOff',


### PR DESCRIPTION
Adds read access to Wyze Scale data — the last device class from the open issues.

## Methods
- `getScaleLatestRecord(device[, { userId }])` — most recent measurement
- `getScaleRecords(device[, { userId, startTime, endTime }])` — history range
- `getScaleFamilyMembers(device)`

Records include weight, BMI, body fat %, body water %, BMR, bone mineral, age, etc.

## How
The scale is on its own host (`wyze-scale-service.wyzecam.com`) but signs with the **same olive scheme** as the wall switch / HMS — so it reuses that signature via a new generic `_oliveGet(baseUrl, path, params)` helper. Notably, even `wyze-sdk` left the scale's salt as "unknown"; the default olive salt (`wyze_app_secret_key_132`) signs it correctly.

## Testing
✅ Verified **live**: `getScaleLatestRecord` returns weight + full body composition (`code: 1`). API-surface test updated; 19/19 tests pass.

Closes #17. Bumps to 2.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)