### PR TITLE
Fix getScaleRecords (millisecond timestamps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1051,10 +1051,18 @@ class Wyze {
   }
 
   async getScaleRecords(device, { userId, startTime = 0, endTime = Date.now() } = {}) {
+    // record_range uses MILLISECOND timestamps; start_time 0 = full history.
+    // Resolve the family member from the latest record if not supplied, so
+    // history comes back without the caller having to look up an id first.
+    if (!userId) {
+      const latest = await this.getScaleLatestRecord(device)
+      const r = Array.isArray(latest.data) ? latest.data[0] : latest.data
+      userId = r && (r.family_member_id || r.user_id)
+    }
     const params = {
       did: this.deviceMac(device),
-      start_time: String(Math.floor(startTime / 1000)),
-      end_time: String(Math.floor(endTime / 1000)),
+      start_time: String(Math.floor(startTime)),
+      end_time: String(Math.floor(endTime)),
     }
     if (userId) params.family_member_id = userId
     return await this._oliveGet(SCALE.baseUrl, '/plugin/scale/get_record_range', params)


### PR DESCRIPTION
`get_record_range` expects **millisecond** bounds; the seconds conversion made every window fall before the first record, so history always came back empty. Now uses ms and auto-resolves `family_member_id` from the latest record when not given — so `getScaleRecords(scale)` returns full history with no args. Verified live (774 records). 2.11.1.