### PR TITLE
Notification event polling (markEventsRead + recipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ await wyze.saveCameraSnapshot(cam, 'driveway.jpg')
 
 - wyze.getEventList({ deviceMacList, count, beginTime, endTime })  // motion/sound events
 - wyze.getEventVideoURL({ deviceMac, deviceModel, beginTime, endTime })  // cloud clip replay URL
+- wyze.markEventsRead(events[, { read }])  // mark notification events read/unread
+
+For forwarding Wyze notifications elsewhere (LCD, webhook, …), poll the event
+list — see the [Notifications guide](docs/guides/notifications.md).
 
 ```
 const cam = await wyze.getDeviceByName('Front Camera')

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ console.log(await wyze.getLockInfo(lock))   // { locked, battery, … }
 |---|---|---|
 | Lights & bulbs | color bulbs, white bulbs, light strips, groups | [Lights](guides/lights.md) |
 | Cameras | controls, thumbnails, events, live snapshots | [Cameras](guides/cameras.md) |
+| Notifications | event feed + polling recipe | [Notifications](guides/notifications.md) |
 | Vacuum / Lock / Switches / Plugs / Garage / HMS | the rest of the house | [Home Devices](guides/home-devices.md) |
 
 ## 🚀 Get started

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -1,0 +1,60 @@
+# 🔔 Notifications & Events
+
+*Wyze's notification feed, and how to forward it anywhere.*
+
+Wyze delivers real-time push notifications to its mobile apps over FCM/APNs — a channel that **isn't reachable from the REST API**. So there's no "subscribe" call. What you *can* read is the thing those push messages are about: the **event feed** (motion, sound, person, package, etc.) — the same list the Wyze app's **Events** tab shows.
+
+The pattern for "Wyze notifications → somewhere else" (an LCD, a webhook, a chat) is therefore **polling**: check the event list on an interval, forward anything new, and mark it read.
+
+## 🛠️ Methods
+
+| Method | Description |
+| --- | --- |
+| `getEventList({ deviceMacList, count, beginTime, endTime })` | Recent events (motion/sound/person/…) |
+| `markEventsRead(events, { read })` | Mark events read (`read: false` to mark unread) |
+| `cameraNotificationsOn/Off(device)` | Whether a camera *generates* notifications at all |
+
+## ⏱️ Polling recipe
+
+A small loop that forwards new events and dismisses them:
+
+```js
+const Wyze = require('wyze-node')
+const wyze = new Wyze({ username, password, keyId, apiKey })
+
+const seen = new Set()
+
+async function pollOnce(onEvent) {
+  const cams = await wyze.getOnlineCameras()
+  const res = await wyze.getEventList({ deviceMacList: cams.map(c => c.mac), count: 20 })
+  const events = (res.data && (res.data.event_list || res.data)) || []
+
+  const fresh = events.filter(e => !seen.has(e.event_id))
+  for (const e of fresh) {
+    seen.add(e.event_id)
+    onEvent(e)                       // forward to your LCD / webhook / etc.
+  }
+  if (fresh.length) await wyze.markEventsRead(fresh)   // dismiss in the app too
+}
+
+// every 20 seconds
+setInterval(() => {
+  pollOnce((e) => {
+    console.log(new Date(Number(e.event_ts)).toLocaleString(),
+                e.device_mac, '→', e.event_value)   // e.g. "Person", "Motion"
+  }).catch(console.error)
+}, 20_000)
+```
+
+> **Note:** Each event carries `event_id`, `device_mac`, `event_value` (the type),
+> `event_ts`, `read_state`, and `file_list` / `event_resources` (thumbnail &
+> clip URLs). Use `event_id` to de-duplicate across polls.
+
+> **⚠️** Polling interval is up to you — every 15–30s is a sane balance. Wyze
+> events usually appear within a few seconds of the trigger.
+
+## What about true push?
+
+There isn't a public path to it. Wyze's push tokens are tied to the mobile apps;
+the event list is the supported, stable source — and it's exactly what a push
+handler would hand you anyway.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-node",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/noelportugal/wyze-node",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -239,6 +239,37 @@ class Wyze {
   }
 
   /**
+  * markEventsRead — mark notification events read (or unread). Pass event
+  * objects from getEventList(); they're grouped by device automatically.
+  * @param {Array<{device_mac:string,event_id:string}>} events
+  * @param {{read?:boolean}} [opts]
+  * @returns {data}
+  */
+  async markEventsRead(events, { read = true } = {}) {
+    await this.getTokens();
+    if (!this.accessToken) {
+      await this.login()
+    }
+    const byMac = {}
+    for (const e of (events || [])) {
+      const mac = e.device_mac || e.deviceMac
+      const id = e.event_id || e.eventId || e.id
+      if (!mac || !id) continue
+      ;(byMac[mac] = byMac[mac] || []).push(id)
+    }
+    const data = {
+      event_list: Object.keys(byMac).map(mac => ({ device_mac: mac, event_id_list: byMac[mac], event_type: 1 })),
+      read_state: read ? 1 : 0,
+    }
+    let result = await axios.post(`${this.baseUrl}/app/v2/device_event/set_read_state_list`, await this.getRequestBodyData(data))
+    if (result.data.msg === 'AccessTokenError') {
+      await this.getRefreshToken()
+      return this.markEventsRead(events, { read })
+    }
+    return result.data
+  }
+
+  /**
    * run action
    * @returns {data}
    */

--- a/tests/api-surface.test.js
+++ b/tests/api-surface.test.js
@@ -14,7 +14,7 @@ const EXPECTED_METHODS = [
   'runAction', 'runActionList', 'runActionListBatch', 'setProperty', 'getPropertyList',
   'turnOn', 'turnOff', 'getDeviceState', 'deviceMac',
   // events
-  'getEventList', 'getEventVideoURL',
+  'getEventList', 'getEventVideoURL', 'markEventsRead',
   // lights + groups
   'isMeshBulb', 'isLightStrip', 'setBrightness', 'setColorTemp', 'setColor', 'setSunMatch',
   'getDeviceGroupByName', 'turnOnGroup', 'turnOffGroup', 'setGroupBrightness',


### PR DESCRIPTION
Resolves #37. There's no Wyze push-subscription API (real-time push is FCM/APNs, outside the REST API), so the supported approach is polling the event feed. Adds the missing primitive:

- `markEventsRead(events, { read })` → `set_read_state_list`, so a poller can dismiss events after forwarding. Verified live (read → restore-unread round-trip, both code 1).
- `docs/guides/notifications.md` — a copy-paste polling recipe for 'Wyze notifications → LCD/webhook'.

Closes #37. 2.12.0.