### PR TITLE
fix: snapshot capture exits cleanly + skips TURN by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ await wyze.turnOffGroup(office)
 
 - wyze.getCameraSignalingInfo(device)  // { signalingUrl, iceServers, authToken }
 - wyze.getCameraStreamInfo(device[, { substream }])  // raw get-streams response
-- wyze.cameraCaptureSnapshot(device[, { timeoutMs }])  // live JPEG Buffer
-- wyze.saveCameraSnapshot(device, filePath)  // capture + write to file
+- wyze.cameraCaptureSnapshot(device[, { timeoutMs, relay }])  // live JPEG Buffer
+- wyze.saveCameraSnapshot(device, filePath[, { timeoutMs, relay }])  // capture + write to file
 
 `getCameraSignalingInfo` returns the AWS Kinesis Video signaling URL + ICE/TURN
 servers. `cameraCaptureSnapshot` goes the whole way — it negotiates a live
@@ -148,8 +148,21 @@ await wyze.saveCameraSnapshot(cam, 'driveway.jpg')
 ```
 
 > Live capture needs optional deps: `npm install werift ws ffmpeg-static`.
-> The camera must be online. For a one-shot CLI, call `process.exit(0)` after
-> saving (the WebRTC stack keeps the event loop alive).
+> The camera must be online.
+
+**`relay` (TURN policy)** — defaults to `'never'`: the capture uses direct/STUN
+candidates only, which is faster and lets the process **exit on its own** when
+done. (werift keeps a TURN keepalive timer that `pc.close()` doesn't clear, so
+any relay allocation otherwise pins the event loop.) If your camera isn't
+reachable on your local network and needs a relay, pass `{ relay: 'auto' }` to
+re-include TURN — but then call `process.exit(0)` after saving, since the loop
+won't drain on its own:
+
+```
+// remote / relay-only network
+await wyze.saveCameraSnapshot(cam, 'frame.jpg', { relay: 'auto' })
+process.exit(0)
+```
 
 ### Camera events
 

--- a/docs/guides/cameras.md
+++ b/docs/guides/cameras.md
@@ -119,8 +119,8 @@ Wyze cameras stream over AWS Kinesis Video WebRTC using H.264. These helpers exp
 | --- | --- |
 | `getCameraSignalingInfo(device)` | Returns `{ signalingUrl, iceServers, authToken }` for a WebRTC session. |
 | `getCameraStreamInfo(device, { substream })` | Returns the raw stream-info response (optionally the lower-bitrate substream). |
-| `cameraCaptureSnapshot(device, { timeoutMs })` | Negotiates a live WebRTC session and returns a single JPEG frame as a `Buffer`. |
-| `saveCameraSnapshot(device, filePath)` | Captures a live frame and writes it to `filePath`, returning the path. |
+| `cameraCaptureSnapshot(device, { timeoutMs, relay })` | Negotiates a live WebRTC session and returns a single JPEG frame as a `Buffer`. |
+| `saveCameraSnapshot(device, filePath, { timeoutMs, relay })` | Captures a live frame and writes it to `filePath`, returning the path. |
 
 `cameraCaptureSnapshot()` and `saveCameraSnapshot()` open a real WebRTC session and pull one frame through ffmpeg, so they need a few optional dependencies that aren't installed by default:
 
@@ -146,3 +146,19 @@ const { signalingUrl, iceServers, authToken } = await wyze.getCameraSignalingInf
 ```
 
 > **⚠️** The camera must be **online** to capture a live frame — an offline camera has no signaling URL, so `cameraCaptureSnapshot()` and `saveCameraSnapshot()` will fail. Filter with `getOnlineCameras()` (or check the device's connection state) before attempting a live capture.
+
+#### TURN relay & clean exit (`relay`)
+
+Both capture methods accept a `relay` option:
+
+- **`'never'` (default)** — direct/STUN candidates only. Faster, and the process **exits on its own** after the capture. Ideal when you're on the same network as the camera (the usual case).
+- **`'auto'`** — also offers TURN relay servers, for when the camera isn't reachable on your local network. Note: werift keeps a TURN keepalive timer that survives `pc.close()`, so in this mode the Node event loop stays alive — call `process.exit(0)` after saving in a one-shot script.
+
+```js
+// Same network (default): captures and the process drains cleanly.
+await wyze.saveCameraSnapshot(cam, './frame.jpg')
+
+// Remote / relay-only network:
+await wyze.saveCameraSnapshot(cam, './frame.jpg', { relay: 'auto' })
+process.exit(0)
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,10 +32,16 @@ The camera is offline. Live capture needs an online camera — check `getOnlineC
 `ffmpeg-static` failed to fetch a binary for your platform. Re-run `npm install`, or install `ffmpeg` on your system PATH as a fallback.
 
 **My script hangs after capturing a frame**
-The WebRTC stack (werift) keeps the Node event loop alive after a capture. For a one-shot CLI tool, call `process.exit(0)` once you've saved the image:
+By default (`relay: 'never'`) capture uses direct/STUN candidates only and the
+process drains on its own once the frame is saved — no `process.exit` needed.
+
+If you pass `{ relay: 'auto' }` (needed only when the camera isn't reachable on
+your local network), werift keeps a TURN keepalive timer that `pc.close()`
+doesn't clear, so the event loop stays alive. For a one-shot CLI in that mode,
+call `process.exit(0)` once you've saved the image:
 
 ```js
-const path = await wyze.saveCameraSnapshot(cam, 'frame.jpg')
+const path = await wyze.saveCameraSnapshot(cam, 'frame.jpg', { relay: 'auto' })
 console.log('saved', path)
 process.exit(0)
 ```

--- a/src/cameraStream.js
+++ b/src/cameraStream.js
@@ -52,6 +52,33 @@ function resolveFfmpeg() {
   return _ffmpegPath
 }
 
+// A cancelable timeout. Returns a promise that rejects after `ms`, plus a
+// cancel() that clears the underlying timer so it never outlives the capture.
+// The timer is unref'd so it alone can't keep the process alive.
+function makeDeadline(ms) {
+  let timer = null
+  const promise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`capture timed out after ${ms}ms`)), ms)
+    if (typeof timer.unref === 'function') timer.unref()
+  })
+  // Swallow the rejection if nobody is racing it at cancel time, so a resolved
+  // capture doesn't surface an unhandled rejection.
+  promise.catch(() => {})
+  return {
+    promise,
+    cancel() { if (timer) { clearTimeout(timer); timer = null } },
+  }
+}
+
+// A bounded, non-blocking sleep. The timer is unref'd so this delay alone can
+// never keep the process alive — it only caps how long we wait for teardown.
+function delay(ms) {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms)
+    if (typeof t.unref === 'function') t.unref()
+  })
+}
+
 function pickFreeUdpPort() {
   return new Promise((resolve, reject) => {
     const sock = dgram.createSocket('udp4')
@@ -143,9 +170,26 @@ async function captureStreamFrame({ signalingUrl, iceServers, timeoutMs = 20_000
   const sdpPath = writeSdpFile(rtpPort)
 
   let ffmpeg = null, pc = null, ws = null, fwdSock = null
-  const cleanup = () => {
+  // A single cancelable deadline shared by every race below. The setTimeout
+  // handle MUST be cleared on the way out — otherwise a *successful* capture
+  // leaves this timer pending for the rest of timeoutMs, holding the event
+  // loop open and preventing a CLI/one-shot caller from exiting. `.unref()`
+  // belt-and-suspenders so a stray reference never pins the process either.
+  const deadline = makeDeadline(timeoutMs)
+  // `pc.close()` is async: werift only tears down its ICE consent / DTLS
+  // keepalive timers once that promise resolves. Firing it and forgetting
+  // (a sync finally) returns the frame while those timers are still pending,
+  // which pins the event loop and stops a one-shot caller from exiting. So we
+  // AWAIT it — bounded by a short unref'd cap so a wedged close can't hang us.
+  const cleanup = async () => {
+    deadline.cancel()
     try { ws?.close() } catch (_) {}
-    try { pc?.close() } catch (_) {}
+    try {
+      const closed = pc?.close()
+      if (closed && typeof closed.then === 'function') {
+        await Promise.race([closed, delay(2000)])
+      }
+    } catch (_) {}
     try { fwdSock?.close() } catch (_) {}
     try { ffmpeg?.kill('SIGKILL') } catch (_) {}
     try { fs.unlinkSync(sdpPath) } catch (_) {}
@@ -194,7 +238,7 @@ async function captureStreamFrame({ signalingUrl, iceServers, timeoutMs = 20_000
       ws.once('close', (code) => { if (code !== 1000) reject(new Error(`signaling WS closed (${code})`)) })
     })
 
-    const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error(`capture timed out after ${timeoutMs}ms`)), timeoutMs))
+    const timeout = deadline.promise
 
     await Promise.race([
       new Promise((resolve, reject) => { ws.once('open', resolve); ws.once('error', reject) }),
@@ -213,8 +257,8 @@ async function captureStreamFrame({ signalingUrl, iceServers, timeoutMs = 20_000
     log('debug', `captured ${buffer.length} bytes`)
     return buffer
   } finally {
-    cleanup()
+    await cleanup()
   }
 }
 
-module.exports = { captureStreamFrame }
+module.exports = { captureStreamFrame, makeDeadline }

--- a/src/index.js
+++ b/src/index.js
@@ -1250,18 +1250,49 @@ class Wyze {
     return { signalingUrl, iceServers }
   }
 
+  // Drop TURN (relay) ICE servers from a normalized list. werift's TURN client
+  // keeps a keepalive/refresh timer alive that `pc.close()` does NOT clear, so
+  // any TURN allocation pins the Node event loop and stops a one-shot process
+  // from exiting on its own. For the common case — capturing your own camera on
+  // your own network — host/STUN candidates connect directly, so dropping TURN
+  // is both faster and lets the process drain cleanly.
+  _filterIceServers(iceServers, relay) {
+    if (relay === 'auto') return iceServers
+    const isTurn = (s) => /\bturns?:/i.test([].concat(s.urls || []).join(','))
+    return iceServers.filter((s) => !isTurn(s))
+  }
+
   /**
   * cameraCaptureSnapshot — capture a live JPEG frame from a camera over WebRTC.
   * Returns the image as a Buffer. Requires the optional deps werift / ws /
   * ffmpeg-static (npm install werift ws ffmpeg-static).
+  *
+  * @param {object} device
+  * @param {object} [opts]
+  * @param {number} [opts.timeoutMs=20000]
+  * @param {object} [opts.logger]
+  * @param {'never'|'auto'} [opts.relay='never'] TURN relay policy. 'never'
+  *   (default) skips TURN servers — direct/STUN only — which is faster and lets
+  *   the process exit cleanly (werift leaks a TURN keepalive timer otherwise).
+  *   Use 'auto' if the camera isn't reachable on your local network and needs a
+  *   relay; note the process may then not exit on its own (call process.exit()).
   * @returns {Promise<Buffer>} JPEG bytes
   */
-  async cameraCaptureSnapshot(device, { timeoutMs = 20000, logger = null } = {}) {
+  async cameraCaptureSnapshot(device, { timeoutMs = 20000, logger = null, relay = 'never' } = {}) {
     const bundle = await this.getCameraSignalingInfo(device)
-    const { signalingUrl, iceServers } = this._normalizeStreamBundle(bundle)
+    const norm = this._normalizeStreamBundle(bundle)
+    const signalingUrl = norm.signalingUrl
     if (!signalingUrl) throw new Error('No signaling URL returned for this camera (is it online?)')
+    const iceServers = this._filterIceServers(norm.iceServers, relay)
     const { captureStreamFrame } = require('./cameraStream')
-    return await captureStreamFrame({ signalingUrl, iceServers, timeoutMs, logger })
+    try {
+      return await captureStreamFrame({ signalingUrl, iceServers, timeoutMs, logger })
+    } catch (err) {
+      if (relay !== 'auto' && /timed out/i.test(err && err.message || '')) {
+        err.message += " — if this camera isn't on your local network, retry with { relay: 'auto' }"
+      }
+      throw err
+    }
   }
 
   /**

--- a/tests/cameraStream.test.js
+++ b/tests/cameraStream.test.js
@@ -9,7 +9,15 @@ const { makeDeadline } = require('../src/cameraStream.js')
 
 test('makeDeadline rejects after the timeout elapses', async () => {
   const d = makeDeadline(10)
-  await assert.rejects(() => d.promise, /timed out after 10ms/)
+  // The deadline timer is unref'd (so it can't keep a real process alive). On
+  // Node 18 the test runner exits the loop when only unref'd timers remain, so
+  // hold it open with a ref'd timer until the deadline has had time to fire.
+  const keepAlive = setTimeout(() => {}, 1000)
+  try {
+    await assert.rejects(() => d.promise, /timed out after 10ms/)
+  } finally {
+    clearTimeout(keepAlive)
+  }
 })
 
 test('cancel() clears the timer and stops it from firing', async () => {

--- a/tests/cameraStream.test.js
+++ b/tests/cameraStream.test.js
@@ -1,0 +1,39 @@
+'use strict'
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { makeDeadline } = require('../src/cameraStream.js')
+
+// Regression: a successful capture used to leave the timeout's setTimeout
+// pending for the rest of timeoutMs, holding the event loop open so a one-shot
+// CLI caller never exited. makeDeadline must clear its timer on cancel().
+
+test('makeDeadline rejects after the timeout elapses', async () => {
+  const d = makeDeadline(10)
+  await assert.rejects(() => d.promise, /timed out after 10ms/)
+})
+
+test('cancel() clears the timer and stops it from firing', async () => {
+  const d = makeDeadline(20)
+  d.cancel()
+  // Wait past the original deadline; the promise must stay pending (never reject).
+  const settled = await Promise.race([
+    d.promise.then(() => 'resolved', () => 'rejected'),
+    new Promise((r) => setTimeout(() => r('still-pending'), 60)),
+  ])
+  assert.equal(settled, 'still-pending')
+})
+
+test('cancel() leaves no active Timeout holding the event loop', async () => {
+  const before = process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length
+  const d = makeDeadline(10_000)
+  d.cancel()
+  const after = process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length
+  // The unref'd timer is cleared, so it must not add a live Timeout resource.
+  assert.equal(after, before)
+})
+
+test('cancel() is idempotent', () => {
+  const d = makeDeadline(50)
+  d.cancel()
+  assert.doesNotThrow(() => d.cancel())
+})

--- a/tests/devices.test.js
+++ b/tests/devices.test.js
@@ -72,3 +72,28 @@ test('isTokenError matches all of Wyze\'s expired-token shapes', () => {
   assert.equal(wyze.isTokenError(null), false)
   assert.equal(wyze.isTokenError(undefined), false)
 })
+
+test('_filterIceServers drops TURN by default, keeps it on relay:auto', () => {
+  const servers = [
+    { urls: 'stun:stun.example:19302' },
+    { urls: 'turn:relay.example:443', username: 'u', credential: 'c' },
+    { urls: 'turns:relay.example:5349', username: 'u', credential: 'c' },
+  ]
+  // Default ('never') keeps only non-relay candidates — this is what lets a
+  // one-shot capture exit cleanly (no werift TURN keepalive timer).
+  assert.deepEqual(wyze._filterIceServers(servers, 'never'), [
+    { urls: 'stun:stun.example:19302' },
+  ])
+  // 'auto' preserves the full list for relay-only networks.
+  assert.deepEqual(wyze._filterIceServers(servers, 'auto'), servers)
+})
+
+test('_filterIceServers handles array-form urls', () => {
+  const servers = [
+    { urls: ['stun:a:19302', 'turn:b:443'] }, // mixed entry counts as TURN
+    { urls: ['stun:c:19302'] },
+  ]
+  assert.deepEqual(wyze._filterIceServers(servers, 'never'), [
+    { urls: ['stun:c:19302'] },
+  ])
+})


### PR DESCRIPTION
## What & why

The WebRTC snapshot path left the Node event loop pinned after a **successful** capture, so one-shot callers never exited on their own (previously worked around downstream with `process.exit(0)`). This fixes it at the source.

Two real timer leaks were keeping the loop alive:

1. **The capture timeout was never cleared.** `captureStreamFrame` raced a bare `setTimeout(…, timeoutMs)` that nothing ever cleared — so a capture that finished in 4s still left that timer pending for the rest of `timeoutMs` (up to 20s). Replaced with a small cancelable, `unref`'d deadline that `cleanup()` clears.

2. **werift's TURN keepalive timer survives `pc.close()`**, and `close()` is async but was fire-and-forgotten in a synchronous `finally`. Traced via `async_hooks` to `werift/lib/ice/src/turn/protocol.js`. Two-part fix:
   - `cleanup()` now **awaits** `pc.close()` (bounded by a short unref'd cap so a wedged close can't hang us), so werift's ICE/DTLS timers drain.
   - Snapshots default to **`relay: 'never'`** — direct/STUN candidates only — which avoids any TURN allocation. For capturing your own camera on your own network this is faster *and* leaves nothing to keep the loop alive.

## New `relay` option

`cameraCaptureSnapshot(device, { relay })` / `saveCameraSnapshot(device, path, { relay })`:

- **`'never'` (default)** — direct/STUN only; fast; process exits on its own.
- **`'auto'`** — re-includes TURN for relay-only / off-LAN networks. werift's TURN timer means you should `process.exit(0)` after saving in that mode (documented). Timeout errors in `'never'` mode append a hint pointing to `{ relay: 'auto' }`.

## Verification

- Live against a real camera: valid **1920×1080** frame in ~3.5s, and the process **drains on its own ~70ms after return** with **no `process.exit`** — confirmed via a watchdog + `process.getActiveResourcesInfo()`.
- `npm test`: **25/25 green** (added a `makeDeadline` suite proving the timer is cleared on cancel, and `_filterIceServers` cases).
- Docs updated: README, `docs/guides/cameras.md`, `docs/troubleshooting.md`.

Independent of #52 (token-refresh); branches off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)